### PR TITLE
Add quotes to error messages to make them parseable as hash.

### DIFF
--- a/lib/membrane/schemas/record.rb
+++ b/lib/membrane/schemas/record.rb
@@ -72,7 +72,12 @@ class Membrane::Schemas::Record < Membrane::Schemas::Base
     end
 
     def fail!(errors)
-      emsg = "{ " + errors.map { |k, e| "#{k} => #{e}" }.join(", ") + " }"
+      emsg =
+        if ENV['MEMBRANE_ERROR_USE_QUOTES']
+          "{ " + errors.map { |k, e| "'#{k}' => '#{e}'" }.join(", ") + " }"
+        else
+          "{ " + errors.map { |k, e| "#{k} => #{e}" }.join(", ") + " }"
+        end
       raise Membrane::SchemaValidationError.new(emsg)
     end
   end

--- a/lib/membrane/schemas/record.rb
+++ b/lib/membrane/schemas/record.rb
@@ -74,7 +74,7 @@ class Membrane::Schemas::Record < Membrane::Schemas::Base
     def fail!(errors)
       emsg =
         if ENV['MEMBRANE_ERROR_USE_QUOTES']
-          "{ " + errors.map { |k, e| "'#{k}' => '#{e}'" }.join(", ") + " }"
+          "{ " + errors.map { |k, e| "'#{k}' => %q(#{e})" }.join(", ") + " }"
         else
           "{ " + errors.map { |k, e| "#{k} => #{e}" }.join(", ") + " }"
         end

--- a/spec/schemas/record_spec.rb
+++ b/spec/schemas/record_spec.rb
@@ -86,6 +86,31 @@ describe Membrane::Schemas::Record do
         }.to_not raise_error
       end
     end
+
+    context "when ENV['MEMBRANE_ERROR_USE_QUOTES'] is set" do
+      it "returns an error message that can be parsed" do
+        ENV['MEMBRANE_ERROR_USE_QUOTES'] = 'true'
+        rec_schema = Membrane::SchemaParser.parse do
+          { "a_number"  => Integer,
+            "tf"        => bool,
+            "seventeen" => 17,
+          }
+        end
+        error_hash = nil
+        begin
+          rec_schema.validate({ 'tf' => 'who knows', 'seventeen' => 18 })
+        rescue Membrane::SchemaValidationError => e
+          error_hash = eval(e.to_s)
+        end
+        error_hash.should include(
+          'tf' => 'Expected instance of true or false, given who knows')
+        error_hash.should include(
+          'a_number' => 'Missing key')
+        error_hash.should include(
+          'seventeen' => 'Expected 17, given 18')
+        ENV.delete('MEMBRANE_ERROR_USE_QUOTES')
+      end
+    end
   end
 
   describe "#parse" do


### PR DESCRIPTION
Controlled by presence of environment variable MEMBRANE_ERROR_USE_QUOTES

https://github.com/cloudfoundry/membrane/issues/3
